### PR TITLE
refactor: Rename ITimerService.StartNew() to StartSingleShot()

### DIFF
--- a/sources/Capsule.Core/ITimerService.cs
+++ b/sources/Capsule.Core/ITimerService.cs
@@ -13,7 +13,7 @@ public interface ITimerService
     /// the capsule to guarantee thread-safety in timer callbacks.
     /// </summary>
     /// <returns>A reference to the timer that allows cancelling the timer before it expires.</returns>
-    TimerReference StartNew(TimeSpan timeout, Func<Task> callback);
+    TimerReference StartSingleShot(TimeSpan timeout, Func<Task> callback);
 
     /// <summary>
     /// Cancel all pending timers. 

--- a/sources/Capsule.Core/TimerService.cs
+++ b/sources/Capsule.Core/TimerService.cs
@@ -21,7 +21,7 @@ internal class TimerService(
     // Internal for unit test access
     internal readonly List<TimerReference> Timers = [];
 
-    public TimerReference StartNew(TimeSpan timeout, Func<Task> callback)
+    public TimerReference StartSingleShot(TimeSpan timeout, Func<Task> callback)
     {
         if (timeout < TimeSpan.Zero)
         {

--- a/sources/Capsule.Test/AutomatedTests/DeviceSample/Impl/FooDevice.cs
+++ b/sources/Capsule.Test/AutomatedTests/DeviceSample/Impl/FooDevice.cs
@@ -32,7 +32,7 @@ public class FooDevice : IDevice, CapsuleFeature.IInitializer, CapsuleFeature.IT
     [Expose]
     public async Task<bool> SetOutputAsync(string id, bool value)
     {
-        Timers!.StartNew(TimeSpan.FromSeconds(10), async () => await ReadIosAsync());
+        Timers!.StartSingleShot(TimeSpan.FromSeconds(10), async () => await ReadIosAsync());
         return true;
     }
 

--- a/sources/Capsule.Test/AutomatedTests/UnitTests/TimerServiceTest.cs
+++ b/sources/Capsule.Test/AutomatedTests/UnitTests/TimerServiceTest.cs
@@ -26,7 +26,7 @@ public class TimerServiceTest
         var callback = async Task () => callbackCalled = true;
 
         // Act 1 - start timer
-        var timerRef = sut.StartNew(TimeSpan.FromSeconds(30), callback);
+        var timerRef = sut.StartSingleShot(TimeSpan.FromSeconds(30), callback);
         await Task.Delay(100);
 
         // Assert 1 - awaiting delay, no invocation enqueued yet
@@ -72,7 +72,7 @@ public class TimerServiceTest
         var callback = async Task () => callbackCalled = true;
 
         // Act 1 - start timer
-        var timerRef = sut.StartNew(TimeSpan.FromSeconds(30), callback);
+        var timerRef = sut.StartSingleShot(TimeSpan.FromSeconds(30), callback);
         await Task.Delay(100);
 
         // Assert 1 - awaiting delay, no invocation enqueued yet


### PR DESCRIPTION
Rename before 1.0 to clarify that such timers will fire only once. Also, this makes way for implementing continuous timers later.