### PR TITLE
Fix: dispose deadlock

### DIFF
--- a/sources/Capsule.Core/Attribution/CapsuleSynchronization.cs
+++ b/sources/Capsule.Core/Attribution/CapsuleSynchronization.cs
@@ -24,5 +24,13 @@ public enum CapsuleSynchronization
     /// Directly invoke the capsule implementation, thus bypassing the thread-safe queue. This synchronization mode
     /// is only safe on immutable properties.
     /// </summary>
-    PassThrough
+    PassThrough,
+    
+    /// <summary>
+    /// Synchronization mode depends on the invocation queue status. If the queue is live and ready to receive
+    /// invocations, <see cref="AwaitCompletion"/> is used. Otherwise, <see cref="PassThrough"/> is used. In the latter
+    /// case, make sure the method is not used concurrently, as there are no thread-safety guarantees with
+    /// <see cref="PassThrough"/>.
+    /// </summary>
+    AwaitCompletionOrPassThroughIfQueueClosed
 }

--- a/sources/Capsule.Core/DefaultInvocationLoopFactory.cs
+++ b/sources/Capsule.Core/DefaultInvocationLoopFactory.cs
@@ -4,8 +4,11 @@ namespace Capsule;
 
 public class DefaultInvocationLoopFactory(ICapsuleLogger<ICapsuleInvocationLoop> logger) : ICapsuleInvocationLoopFactory
 {
-    public ICapsuleInvocationLoop Create(ChannelReader<Func<Task>> reader, Type capsuleType)
+    public ICapsuleInvocationLoop Create(
+        ChannelReader<Func<Task>> reader,
+        InvocationLoopStatus status,
+        Type capsuleType)
     {
-        return new InvocationLoop(reader, capsuleType, logger);
+        return new InvocationLoop(reader, status, capsuleType, logger);
     }
 }

--- a/sources/Capsule.Core/DefaultSynchronizerFactory.cs
+++ b/sources/Capsule.Core/DefaultSynchronizerFactory.cs
@@ -8,12 +8,14 @@ public class DefaultSynchronizerFactory(
     {
         var capsuleType = capsuleImpl.GetType();
         
+        var invocationLoopStatus = new InvocationLoopStatus();
+        
         var queue = queueFactory.CreateSynchronizerQueue();
-        var synchronizer = new CapsuleSynchronizer(queue.Writer, capsuleType);
+        var synchronizer = new CapsuleSynchronizer(queue.Writer, invocationLoopStatus, capsuleType);
 
         ApplyFeatures(capsuleImpl, synchronizer);
 
-        host.Register(invocationLoopFactory.Create(queue.Reader, capsuleType));
+        host.Register(invocationLoopFactory.Create(queue.Reader, invocationLoopStatus, capsuleType));
 
         return synchronizer;
     }

--- a/sources/Capsule.Core/ICapsuleInvocationLoopFactory.cs
+++ b/sources/Capsule.Core/ICapsuleInvocationLoopFactory.cs
@@ -4,5 +4,8 @@ namespace Capsule;
 
 public interface ICapsuleInvocationLoopFactory
 {
-    ICapsuleInvocationLoop Create(ChannelReader<Func<Task>> reader, Type capsuleType);
+    ICapsuleInvocationLoop Create(
+        ChannelReader<Func<Task>> reader,
+        InvocationLoopStatus status,
+        Type capsuleType);
 }

--- a/sources/Capsule.Core/ICapsuleSynchronizer.cs
+++ b/sources/Capsule.Core/ICapsuleSynchronizer.cs
@@ -8,13 +8,25 @@ public interface ICapsuleSynchronizer
     /// <summary>
     /// Enqueues an invocation and awaits its completion. Exceptions are routed back to the caller.
     /// </summary>
-    Task EnqueueAwaitResult(Func<Task> impl);
+    /// <param name="impl">The invocation</param>
+    /// <param name="passThroughIfQueueClosed">
+    /// If true and the queue has been terminated, the invocation will not be enqueued, but executed directly (same
+    /// behavior as <see cref="PassThrough{T}"/>). This means thread-safety cannot be guaranteed in that case.
+    /// Only use this if you're sure the method will not be called concurrently.
+    /// </param>
+    Task EnqueueAwaitResult(Func<Task> impl, bool passThroughIfQueueClosed = false);
     
     /// <summary>
     /// Enqueues an invocation and awaits its completion, returning the result of the invocation. Exceptions are routed
     /// back to the caller.
     /// </summary>
-    Task<T> EnqueueAwaitResult<T>(Func<Task<T>> impl);
+    /// <param name="impl">The invocation</param>
+    /// <param name="passThroughIfQueueClosed">
+    /// If true and the queue has been terminated, the invocation will not be enqueued, but executed directly (same
+    /// behavior as <see cref="PassThrough{T}"/>). This means thread-safety cannot be guaranteed in that case.
+    /// Only use this if you're sure the method will not be called concurrently.
+    /// </param>
+    Task<T> EnqueueAwaitResult<T>(Func<Task<T>> impl, bool passThroughIfQueueClosed = false);
 
     /// <summary>
     /// Enqueues an invocation and awaits reception of the invocation by the capsule implementation. Completion of the

--- a/sources/Capsule.Core/IInvocationLoopStatus.cs
+++ b/sources/Capsule.Core/IInvocationLoopStatus.cs
@@ -1,0 +1,6 @@
+﻿namespace Capsule;
+
+public interface IInvocationLoopStatus
+{
+    bool Terminated { get; }
+}

--- a/sources/Capsule.Core/InvocationLoopStatus.cs
+++ b/sources/Capsule.Core/InvocationLoopStatus.cs
@@ -1,0 +1,16 @@
+﻿namespace Capsule;
+
+/// <summary>
+/// A thread-safe class that provides information from the invocation loop back to the synchronizer.
+/// </summary>
+public class InvocationLoopStatus : IInvocationLoopStatus
+{
+    private int _terminated;
+
+    public bool Terminated => Interlocked.CompareExchange(ref _terminated, 1, 1) == 1;
+
+    public void SetTerminated()
+    {
+        Interlocked.Exchange(ref _terminated, 1);
+    }
+}

--- a/sources/Capsule.Generator/ExposeDefinition.cs
+++ b/sources/Capsule.Generator/ExposeDefinition.cs
@@ -2,4 +2,4 @@
 
 namespace Capsule.Generator;
 
-internal record ExposeDefinition(ISymbol Symbol, Synchronization Synchronization);
+internal record ExposeDefinition(ISymbol Symbol, Synchronization Synchronization, bool PassThroughIfQueueClosed);

--- a/sources/Capsule.Generator/Synchronization.cs
+++ b/sources/Capsule.Generator/Synchronization.cs
@@ -8,5 +8,6 @@ internal enum Synchronization
     EnqueueAwaitResult,
     EnqueueAwaitReception,
     EnqueueReturn,
-    PassThrough
+    PassThrough,
+    EnqueueAwaitResultOrPassThroughIfQueueClosed
 }

--- a/sources/Capsule.Test/AutomatedTests/UnitTests/AwaitCompletionTest.cs
+++ b/sources/Capsule.Test/AutomatedTests/UnitTests/AwaitCompletionTest.cs
@@ -10,16 +10,21 @@ namespace Capsule.Test.AutomatedTests.UnitTests;
 
 public class AwaitCompletionTest
 {
-    [Test]
-    public async Task Await_completion_returns_result_when_method_ran_to_completion_successfully()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Await_completion_returns_result_when_method_ran_to_completion_successfully(bool withFallback)
     {
-        await TestSuccessfulCompletion(s => s.ExecuteInnerAsync());
+        await TestSuccessfulCompletion(s => withFallback ? s.ExecuteWithFallbackAsync() : s.ExecuteInnerAsync());
     }
     
-    [Test]
-    public async Task Await_completion_returns_result_when_method_ran_to_completion_successfully_value_task()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Await_completion_returns_result_when_method_ran_to_completion_successfully_value_task(bool withFallback)
     {
-        await TestSuccessfulCompletion(s => s.ExecuteInnerValueTaskAsync().AsTask());
+        await TestSuccessfulCompletion(
+            s => withFallback
+                ? s.ExecuteValueTaskWithFallbackAsync().AsTask()
+                : s.ExecuteInnerValueTaskAsync().AsTask());
     }
 
     private static async Task TestSuccessfulCompletion(Func<IAwaitCompletionTestSubject, Task<int>> testSubjectCall)

--- a/sources/Capsule.Test/AutomatedTests/UnitTests/AwaitCompletionTestSubject.cs
+++ b/sources/Capsule.Test/AutomatedTests/UnitTests/AwaitCompletionTestSubject.cs
@@ -3,22 +3,13 @@
 namespace Capsule.Test.AutomatedTests.UnitTests;
 
 [Capsule]
-public class AwaitCompletionTestSubject
+public class AwaitCompletionTestSubject(Task innerTask, Func<int> innerFunc)
 {
-    private readonly Task _innerTask;
-    private readonly Func<int> _innerFunc;
-
-    public AwaitCompletionTestSubject(Task innerTask, Func<int> innerFunc)
-    {
-        _innerTask = innerTask;
-        _innerFunc = innerFunc;
-    }
-
     [Expose]
     public async Task<int> ExecuteInnerAsync()
     {
-        await _innerTask;
-        return _innerFunc();
+        await innerTask;
+        return innerFunc();
     }
 
     [Expose]

--- a/sources/Capsule.Test/AutomatedTests/UnitTests/AwaitCompletionTestSubject.cs
+++ b/sources/Capsule.Test/AutomatedTests/UnitTests/AwaitCompletionTestSubject.cs
@@ -11,9 +11,22 @@ public class AwaitCompletionTestSubject(Task innerTask, Func<int> innerFunc)
         await innerTask;
         return innerFunc();
     }
+    
+    [Expose(Synchronization = CapsuleSynchronization.AwaitCompletionOrPassThroughIfQueueClosed)]
+    public async Task<int> ExecuteWithFallbackAsync()
+    {
+        await innerTask;
+        return innerFunc();
+    }
 
     [Expose]
     public async ValueTask<int> ExecuteInnerValueTaskAsync()
+    {
+        return await ExecuteInnerAsync();
+    }
+
+    [Expose(Synchronization = CapsuleSynchronization.AwaitCompletionOrPassThroughIfQueueClosed)]
+    public async ValueTask<int> ExecuteValueTaskWithFallbackAsync()
     {
         return await ExecuteInnerAsync();
     }

--- a/sources/Capsule.Test/AutomatedTests/UnitTests/AwaitEnqueueingTestSubject.cs
+++ b/sources/Capsule.Test/AutomatedTests/UnitTests/AwaitEnqueueingTestSubject.cs
@@ -3,22 +3,13 @@
 namespace Capsule.Test.AutomatedTests.UnitTests;
 
 [Capsule]
-public class AwaitEnqueueingTestSubject
+public class AwaitEnqueueingTestSubject(Task innerTask, Action preAction)
 {
-    private readonly Task _innerTask;
-    private readonly Action _preAction;
-
-    public AwaitEnqueueingTestSubject(Task innerTask, Action preAction)
-    {
-        _innerTask = innerTask;
-        _preAction = preAction;
-    }
-
     [Expose(Synchronization = CapsuleSynchronization.AwaitEnqueueing)]
     public async Task ExecuteInnerAsync()
     {
-        _preAction();
-        await _innerTask;
+        preAction();
+        await innerTask;
     }
 
     [Expose(Synchronization = CapsuleSynchronization.AwaitEnqueueing)]

--- a/sources/Capsule.Test/AutomatedTests/UnitTests/AwaitReceptionTestSubject.cs
+++ b/sources/Capsule.Test/AutomatedTests/UnitTests/AwaitReceptionTestSubject.cs
@@ -3,22 +3,13 @@
 namespace Capsule.Test.AutomatedTests.UnitTests;
 
 [Capsule(InterfaceName = "ISomeAwaitReceptionTestSubject")]
-public class AwaitReceptionTestSubject
+public class AwaitReceptionTestSubject(Task innerTask, Action preAction)
 {
-    private readonly Task _innerTask;
-    private readonly Action _preAction;
-
-    public AwaitReceptionTestSubject(Task innerTask, Action preAction)
-    {
-        _innerTask = innerTask;
-        _preAction = preAction;
-    }
-
     [Expose(Synchronization = CapsuleSynchronization.AwaitReception)]
     public async Task ExecuteInnerAsync()
     {
-        _preAction();
-        await _innerTask;
+        preAction();
+        await innerTask;
     }
 
     [Expose]

--- a/sources/Capsule.Test/AutomatedTests/UnitTests/DisposeTest.cs
+++ b/sources/Capsule.Test/AutomatedTests/UnitTests/DisposeTest.cs
@@ -1,0 +1,45 @@
+﻿using Capsule.Attribution;
+using Capsule.Extensions.DependencyInjection;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+namespace Capsule.Test.AutomatedTests.UnitTests;
+
+public class DisposeTest
+{
+    /// <summary>
+    /// This test reproduces a problem found with ASP.NET Core hosting, where DI-registered services that implement
+    /// IAsyncDisposable are disposed by the DI container on shutdown. However, that happens *after* the
+    /// <see cref="CapsuleBackgroundService"/> has already been shut down, so the dispose call is enqueued by never
+    /// processed.
+    /// </summary>
+    [Test]
+    public async Task Disposing_a_capsule_with_a_closed_invocation_queue_doesnt_deadlock_or_throw()
+    {
+        var runtimeContext = TestRuntime.Create();
+        var hostedService = new CapsuleBackgroundService(
+            (CapsuleHost)runtimeContext.Host,
+            Mock.Of<ILogger<CapsuleBackgroundService>>());
+
+        var sutImpl = new DisposeTestSubject();
+        var sut = sutImpl.Encapsulate(runtimeContext);
+        
+        await hostedService.StartAsync(CancellationToken.None);
+
+        await hostedService.StopAsync(CancellationToken.None);
+
+        // Act & assert
+        await sut.DisposeAsync();
+    }
+}
+
+[Capsule]
+public class DisposeTestSubject : IAsyncDisposable
+{
+    [Expose(Synchronization = CapsuleSynchronization.AwaitCompletionOrPassThroughIfQueueClosed)]
+    public async ValueTask DisposeAsync()
+    {
+    }
+}

--- a/sources/Capsule.Test/AutomatedTests/UnitTests/TimerServiceTest.cs
+++ b/sources/Capsule.Test/AutomatedTests/UnitTests/TimerServiceTest.cs
@@ -114,9 +114,9 @@ public class TimerServiceTest
             }
         }
 
-        public async Task EnqueueAwaitResult(Func<Task> impl) => throw new InvalidOperationException();
+        public async Task EnqueueAwaitResult(Func<Task> impl, bool passThroughIfQueueClosed = false) => throw new InvalidOperationException();
 
-        public async Task<TResult> EnqueueAwaitResult<TResult>(Func<Task<TResult>> impl) => throw new InvalidOperationException();
+        public async Task<TResult> EnqueueAwaitResult<TResult>(Func<Task<TResult>> impl, bool passThroughIfQueueClosed = false) => throw new InvalidOperationException();
 
         public async Task EnqueueAwaitReception(Func<Task> impl) => throw new InvalidOperationException();
 

--- a/sources/Capsule.Testing/FakeSynchronizer.cs
+++ b/sources/Capsule.Testing/FakeSynchronizer.cs
@@ -2,9 +2,9 @@
 
 public class FakeSynchronizer : ICapsuleSynchronizer
 {
-    public Task EnqueueAwaitResult(Func<Task> impl) => impl();
+    public Task EnqueueAwaitResult(Func<Task> impl, bool passThroughIfQueueClosed = false) => impl();
 
-    public Task<T> EnqueueAwaitResult<T>(Func<Task<T>> impl) => impl();
+    public Task<T> EnqueueAwaitResult<T>(Func<Task<T>> impl, bool passThroughIfQueueClosed = false) => impl();
 
     public Task EnqueueAwaitReception(Func<Task> impl) => impl();
 


### PR DESCRIPTION
### Added

- New synchronization mode `AwaitCompletionOrPassThroughIfQueueClosed` added that falls back to `PassThrough` if the invocation queue has been closed. This is the recommended way for `DisposeAsync()` methods to avoid deadlocks on app shutdown.