### PR TITLE
fix: Start invocation loops when the host runs, not when the loops are enqueued

### DIFF
--- a/sources/Capsule.Test/AutomatedTests/CacheSample/CapsuleCacheSample.cs
+++ b/sources/Capsule.Test/AutomatedTests/CacheSample/CapsuleCacheSample.cs
@@ -14,6 +14,7 @@ public class CapsuleCacheSample
     public async Task Use_cache_concurrently()
     {
         using var app = ConfigureHost();
+        await app.StartAsync();
         
         var cache = app.Services.GetRequiredService<IMemoryCache>();
 

--- a/sources/Capsule.Test/AutomatedTests/DeviceSample/CapsuleDeviceSample.cs
+++ b/sources/Capsule.Test/AutomatedTests/DeviceSample/CapsuleDeviceSample.cs
@@ -13,13 +13,11 @@ public class CapsuleDeviceSample
     public async Task RunAsync()
     {
         using var app = ConfigureHost();
+        await app.StartAsync();
 
         var controller = app.Services.GetRequiredService<ListDevicesController>();
         
         await RunExample(controller);
-
-        await app.StopAsync(CancellationToken.None);
-        await Task.Delay(100);
     }
 
     private static IHost ConfigureHost()

--- a/sources/Capsule.Test/AutomatedTests/UnitTests/ConcurrencyTest.cs
+++ b/sources/Capsule.Test/AutomatedTests/UnitTests/ConcurrencyTest.cs
@@ -19,8 +19,6 @@ public class ConcurrencyTest
             (CapsuleHost)runtimeContext.Host,
             Mock.Of<ILogger<CapsuleBackgroundService>>());
         
-        await hostedService.StartAsync(CancellationToken.None);
-
         var sut = new ConcurrencyTestSubject().Encapsulate(runtimeContext);
 
         var taskRes1 = sut.IncrementAwaitResultAsync();
@@ -32,8 +30,9 @@ public class ConcurrencyTest
         var taskRes3 = sut.IncrementAwaitResultAsync();
         var taskRes4 = sut.IncrementAwaitResultAsync();
         
-        sut.GetStateUnsafe().ShouldBe(10);
+        sut.GetStateUnsafe().ShouldBe(0);
 
+        await hostedService.StartAsync(CancellationToken.None);
         await Task.WhenAll(taskRes1, taskRes2, taskRes3, taskRes4, taskE1, taskE2, taskRec1, taskRec2);
         
         taskRes1.Result.ShouldBe(11);


### PR DESCRIPTION
### Fixed

- The invocation loops are now deferred and only started when `CapsuleHost.RunAsync()` runs. This ensures that capsules remain inactive until their assigned host is run.