### PR TITLE
Feature: Expose original timeout in timer reference

### DIFF
--- a/sources/Capsule.Core/TimerReference.cs
+++ b/sources/Capsule.Core/TimerReference.cs
@@ -4,26 +4,35 @@
 /// A reference to a timer that has been registered for delayed execution. The main purpose of this reference is to
 /// allow cancellation of pending timers (<see cref="Cancel"/>).
 /// </summary>
-public class TimerReference(TimeSpan timeout, Task timerTask, CancellationTokenSource cancellationTokenSource)
+public class TimerReference
 {
+    private readonly CancellationTokenSource _cancellationTokenSource;
+
+    internal TimerReference(TimeSpan timeout, Task timerTask, CancellationTokenSource cancellationTokenSource)
+    {
+        _cancellationTokenSource = cancellationTokenSource;
+        TimerTask = timerTask;
+        Timeout = timeout;
+    }
+
     /// <summary>
     /// The task that represents the delay of the timer. This task completes when the timer's callback has been
     /// enqueued.
     /// </summary>
-    internal Task TimerTask { get; } = timerTask;
+    internal Task TimerTask { get; }
 
     /// <summary>
     /// The timeout value that the timer uses.
     /// </summary>
-    public TimeSpan Timeout { get; } = timeout;
+    public TimeSpan Timeout { get; }
 
     /// <summary>
     /// Cancel this timer. If the timer has already fired and the callback enqueued, this is a no-op.
     /// </summary>
-    public void Cancel() => cancellationTokenSource.Cancel();
+    public void Cancel() => _cancellationTokenSource.Cancel();
 
     /// <summary>
     /// The cancellation token that is associated with this timer reference.
     /// </summary>
-    public CancellationToken CancellationToken => cancellationTokenSource.Token;
+    public CancellationToken CancellationToken => _cancellationTokenSource.Token;
 }

--- a/sources/Capsule.Core/TimerReference.cs
+++ b/sources/Capsule.Core/TimerReference.cs
@@ -4,13 +4,18 @@
 /// A reference to a timer that has been registered for delayed execution. The main purpose of this reference is to
 /// allow cancellation of pending timers (<see cref="Cancel"/>).
 /// </summary>
-public class TimerReference(Task timerTask, CancellationTokenSource cancellationTokenSource)
+public class TimerReference(TimeSpan timeout, Task timerTask, CancellationTokenSource cancellationTokenSource)
 {
     /// <summary>
     /// The task that represents the delay of the timer. This task completes when the timer's callback has been
     /// enqueued.
     /// </summary>
     internal Task TimerTask { get; } = timerTask;
+
+    /// <summary>
+    /// The timeout value that the timer uses.
+    /// </summary>
+    public TimeSpan Timeout { get; } = timeout;
 
     /// <summary>
     /// Cancel this timer. If the timer has already fired and the callback enqueued, this is a no-op.

--- a/sources/Capsule.Core/TimerService.cs
+++ b/sources/Capsule.Core/TimerService.cs
@@ -31,7 +31,7 @@ internal class TimerService(
         var cts = new CancellationTokenSource();
 
         var timerTask = EnqueueCallbackDelayed();
-        var timerReference = new TimerReference(timerTask, cts);
+        var timerReference = new TimerReference(timeout, timerTask, cts);
         
         TimerTasks.Add(timerTask);
         Timers.Add(timerReference);

--- a/sources/Capsule.Testing/Capsule.Testing.csproj
+++ b/sources/Capsule.Testing/Capsule.Testing.csproj
@@ -28,8 +28,12 @@
   <ItemGroup>
     <!-- Conditionally reference either the project or the package. This enables integrated development of features
          that span multiple projects, while still resorting to package references for the published nuget packages. -->
+    <!--
     <ProjectReference Include="..\Capsule.Core\Capsule.Core.csproj" Condition=" '$(Configuration)' == 'Debug' " />
     <PackageReference Include="Capsule.Core" Version="1.0.0" Condition=" '$(Configuration)' == 'Release' " />
+    -->
+    <!-- TODO remove following project reference and restore the two conditional references above once 2.0.0 is released -->
+    <ProjectReference Include="..\Capsule.Core\Capsule.Core.csproj" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/sources/Capsule.Testing/FakeTimerService.cs
+++ b/sources/Capsule.Testing/FakeTimerService.cs
@@ -17,7 +17,7 @@ public class FakeTimerService : ITimerService
     public TimerReference StartSingleShot(TimeSpan timeout, Func<Task> callback)
     {
         var cancellationTokenSource = new CancellationTokenSource();
-        var timerReference = new TimerReference(Task.CompletedTask, cancellationTokenSource);
+        var timerReference = new TimerReference(timeout, Task.CompletedTask, cancellationTokenSource);
 
         _callbacks.Add(timerReference, callback);
         


### PR DESCRIPTION
### Added

- `TimerReference` exposes now the timeout value that was used to start the corresponding timer.

### Changed

- `TimerReference` constructor is now internal, as this is not meant to be called by clients. If you're constructing timer references yourself (unlikely), this is a **breaking change**.