### PR TITLE
Fix: Don't fire timers early

### DIFF
--- a/sources/Capsule.Core/TimerService.cs
+++ b/sources/Capsule.Core/TimerService.cs
@@ -16,7 +16,7 @@ internal class TimerService(
     ILogger<TimerService> logger,
     Func<TimeSpan, CancellationToken, Task>? delayProvider = null) : ITimerService
 {
-    private readonly Func<TimeSpan, CancellationToken, Task> _delayProvider = delayProvider ?? Task.Delay;
+    private readonly Func<TimeSpan, CancellationToken, Task> _delayProvider = delayProvider ?? DefaultDelayImpl;
 
     // Internal for unit test access
     internal readonly TaskCollection TimerTasks = [];
@@ -93,4 +93,11 @@ internal class TimerService(
 
         Timers.RemoveAll(t => completed.Contains(t.TimerTask));
     }
+
+    /// <summary>
+    /// The default delay implementation uses Task.Delay but adds 1ms to the delay. The added delay ensures that timers
+    /// never fire early (under normal circumstances).
+    /// </summary>
+    private static async Task DefaultDelayImpl(TimeSpan delay, CancellationToken cancellationToken) =>
+        await Task.Delay(delay + TimeSpan.FromMilliseconds(1), cancellationToken).ConfigureAwait(false);
 }

--- a/sources/Capsule.Test/AutomatedTests/UnitTests/TestRuntime.cs
+++ b/sources/Capsule.Test/AutomatedTests/UnitTests/TestRuntime.cs
@@ -13,7 +13,7 @@ public static class TestRuntime
             host,
             new DefaultSynchronizerFactory(
                 new DefaultQueueFactory(),
-                new DefaultInvocationLoopFactory(
-                    loggerFactory.CreateLogger<ICapsuleInvocationLoop>())));
+                new DefaultInvocationLoopFactory(loggerFactory.CreateLogger<ICapsuleInvocationLoop>()),
+                loggerFactory));
     }
 }

--- a/sources/Capsule.Test/AutomatedTests/UnitTests/TimerServiceTest.cs
+++ b/sources/Capsule.Test/AutomatedTests/UnitTests/TimerServiceTest.cs
@@ -1,4 +1,6 @@
-﻿using Shouldly;
+﻿using Microsoft.Extensions.Logging.Abstractions;
+
+using Shouldly;
 
 namespace Capsule.Test.AutomatedTests.UnitTests;
 
@@ -15,6 +17,7 @@ public class TimerServiceTest
 
         var sut = new TimerService(
             synchronizer,
+            new NullLogger<TimerService>(),
             (ts, ct) =>
             {
                 timeSpan = ts;
@@ -62,6 +65,7 @@ public class TimerServiceTest
 
         var sut = new TimerService(
             synchronizer,
+            new NullLogger<TimerService>(),
             (_, ct) =>
             {
                 ct.Register((_, t) => taskCompletionSource.SetCanceled(t), null);

--- a/sources/Capsule.Test/Capsule.Test.csproj
+++ b/sources/Capsule.Test/Capsule.Test.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.2" />
     <PackageReference Include="Extensions.Logging.NUnit" Version="1.0.1" />
     <PackageReference Include="JunitXml.TestLogger" Version="3.1.12" />
+    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />


### PR DESCRIPTION
### Fix

- Apparently, `Task.Delay` may fire up to 1ms early. This fix accounts for that by adding 1ms to timeouts, so that Capsule timers never fire early.