### PR TITLE
feature: Customizable failure mode for loop owned invocations

### DIFF
--- a/sources/Capsule.Core/CapsuleFailureMode.cs
+++ b/sources/Capsule.Core/CapsuleFailureMode.cs
@@ -1,0 +1,25 @@
+﻿using Capsule.GenericHosting;
+
+namespace Capsule;
+
+/// <summary>
+/// How capsule invocation loops should handle invocation failures, i.e. uncaught exceptions for loop-owned invocations.
+/// </summary>
+public enum CapsuleFailureMode
+{
+    /// <summary>
+    /// Log the failed invocation, then continue with the next one.
+    /// </summary>
+    Continue,
+    
+    /// <summary>
+    /// Escalate and abort the invocation loop. The loop will throw the uncaught exception, pending invocations will
+    /// not be processed anymore.
+    /// </summary>
+    /// <remarks>
+    /// When working with this mode in default Capsule setups, uncaught exceptions will terminate the owning
+    /// <see cref="InvocationLoop"/> and its <see cref="CapsuleHost"/>. The exception then propagates to the
+    /// <see cref="CapsuleBackgroundService"/>, where it will crash the app in .NET 6 and newer.
+    /// </remarks>
+    Abort
+}

--- a/sources/Capsule.Core/DefaultInvocationLoopFactory.cs
+++ b/sources/Capsule.Core/DefaultInvocationLoopFactory.cs
@@ -4,13 +4,22 @@ using Microsoft.Extensions.Logging;
 
 namespace Capsule;
 
-public class DefaultInvocationLoopFactory(ILogger<ICapsuleInvocationLoop> logger) : ICapsuleInvocationLoopFactory
+/// <summary>
+/// A factory for invocation loops. Used when encapsulating capsules.
+/// </summary>
+/// <param name="logger">The logger</param>
+/// <param name="failureMode">
+/// How the invocation loop shall treat uncaught exceptions from loop-owned invocations
+/// </param>
+public class DefaultInvocationLoopFactory(
+    ILogger<ICapsuleInvocationLoop> logger,
+    CapsuleFailureMode failureMode = CapsuleFailureMode.Continue) : ICapsuleInvocationLoopFactory
 {
     public ICapsuleInvocationLoop Create(
         ChannelReader<Func<Task>> reader,
         InvocationLoopStatus status,
         Type capsuleType)
     {
-        return new InvocationLoop(reader, status, capsuleType, logger);
+        return new InvocationLoop(reader, status, capsuleType, logger, failureMode);
     }
 }

--- a/sources/Capsule.Core/DependencyInjection/CapsuleOptions.cs
+++ b/sources/Capsule.Core/DependencyInjection/CapsuleOptions.cs
@@ -1,0 +1,13 @@
+﻿namespace Capsule.DependencyInjection;
+
+/// <summary>
+/// Options for customizing Capsule.
+/// </summary>
+public record CapsuleOptions
+{
+    /// <summary>
+    /// The failure mode that instantiated control loops should use. Defaults to
+    /// <see cref="CapsuleFailureMode.Continue"/>.
+    /// </summary>
+    public CapsuleFailureMode FailureMode { get; set; } = CapsuleFailureMode.Continue;
+}

--- a/sources/Capsule.Core/DependencyInjection/CapsuleServiceCollectionExtensions.cs
+++ b/sources/Capsule.Core/DependencyInjection/CapsuleServiceCollectionExtensions.cs
@@ -1,13 +1,14 @@
 ﻿using Capsule.GenericHosting;
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Capsule.DependencyInjection;
 
 public static class CapsuleServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers Capsule hosting infrastructure and the default factories that Capsule provides.
+    /// Registers Capsule hosting infrastructure and the default factories for running Capsules.
     /// </summary>
     /// <remarks>
     /// This extension method establishes one singleton Capsule environment. This is sufficient for typical cases. For
@@ -16,11 +17,27 @@ public static class CapsuleServiceCollectionExtensions
     /// </remarks>
     public static IServiceCollection AddCapsuleHost(this IServiceCollection services)
     {
+        return AddCapsuleHost(services, new CapsuleOptions());
+    }
+
+    /// <summary>
+    /// Registers Capsule hosting infrastructure and the default factories that Capsule provides.
+    /// </summary>
+    /// <remarks>
+    /// This extension method establishes one singleton Capsule environment. This is sufficient for typical cases. For
+    /// advanced usage where different capsules run on different invocation loops or hosts or use different queue
+    /// settings, you may need to create multiple <see cref="CapsuleRuntimeContext"/> and manage them yourself.
+    /// </remarks>
+    public static IServiceCollection AddCapsuleHost(this IServiceCollection services, CapsuleOptions options)
+    {
         services.AddSingleton<CapsuleHost>();
         services.AddSingleton<ICapsuleHost>(p => p.GetRequiredService<CapsuleHost>());
         
         services.AddSingleton<ICapsuleSynchronizerFactory, DefaultSynchronizerFactory>();
-        services.AddSingleton<ICapsuleInvocationLoopFactory, DefaultInvocationLoopFactory>();
+        services.AddSingleton<ICapsuleInvocationLoopFactory>(
+            p => new DefaultInvocationLoopFactory(
+                p.GetRequiredService<ILogger<ICapsuleInvocationLoop>>(),
+                options.FailureMode));
         services.AddSingleton<ICapsuleQueueFactory, DefaultQueueFactory>();
         
         services.AddSingleton<CapsuleRuntimeContext>();

--- a/sources/Capsule.Test/AutomatedTests/UnitTests/AwaitEnqueueingTest.cs
+++ b/sources/Capsule.Test/AutomatedTests/UnitTests/AwaitEnqueueingTest.cs
@@ -68,13 +68,13 @@ public class AwaitEnqueueingTest
     }
 
     [Test]
-    public async Task Await_enqueueing_does_not_throw_exception_when_capsule_method_throws()
+    public async Task Await_enqueueing_does_not_throw_exception_when_capsule_method_throws_but_host_throws()
     {
         await TestException(s => s.ExecuteInnerAsync());
     }
 
     [Test]
-    public async Task Await_enqueueing_does_not_throw_exception_when_capsule_method_throws_value_task()
+    public async Task Await_enqueueing_does_not_throw_exception_when_capsule_method_throws_but_host_throws_value_task()
     {
         await TestException(s => s.ExecuteInnerValueTaskAsync().AsTask());
     }
@@ -101,22 +101,22 @@ public class AwaitEnqueueingTest
         sutInvocationTask.IsCompleted.ShouldBeTrue();
         sutInvocationTask.IsCompletedSuccessfully.ShouldBeTrue();
         
-        // Ensure that the loop is still active and is able to handle a second invocation
-        (await sut.SucceedAlwaysAsync()).ShouldBeTrue();
+        // Ensure that the loop has been terminated
+        await Should.ThrowAsync<CapsuleInvocationException>(async () => await sut.SucceedAlwaysAsync());
         
         await hostedService.StopAsync(CancellationToken.None);
         await Task.Delay(100);
-        await hostedService.ExecuteTask!;
+        await Should.ThrowAsync<InvalidOperationException>(async () => await hostedService.ExecuteTask);
     }
 
     [Test]
-    public async Task Await_enqueueing_does_not_throw_exception_when_capsule_method_is_cancelled()
+    public async Task Await_enqueueing_does_not_throw_exception_when_capsule_method_is_cancelled_but_host_throws()
     {
         await TestCancellation(s => s.ExecuteInnerAsync());
     }
 
     [Test]
-    public async Task Await_enqueueing_does_not_throw_exception_when_capsule_method_is_cancelled_value_task()
+    public async Task Await_enqueueing_does_not_throw_exception_when_capsule_method_is_cancelled_but_host_throws_value_task()
     {
         await TestCancellation(s => s.ExecuteInnerValueTaskAsync().AsTask());
     }
@@ -142,11 +142,11 @@ public class AwaitEnqueueingTest
         sutInvocationTask.IsCompleted.ShouldBeTrue();
         sutInvocationTask.IsCompletedSuccessfully.ShouldBeTrue();
         
-        // Ensure that the loop is still active and is able to handle a second invocation
-        (await sut.SucceedAlwaysAsync()).ShouldBeTrue();
+        // Ensure that the loop has been terminated
+        await Should.ThrowAsync<CapsuleInvocationException>(async () => await sut.SucceedAlwaysAsync());
         
         await hostedService.StopAsync(CancellationToken.None);
         await Task.Delay(100);
-        await hostedService.ExecuteTask!;
+        await Should.ThrowAsync<OperationCanceledException>(async () => await hostedService.ExecuteTask);
     }
 }

--- a/sources/Capsule.Test/AutomatedTests/UnitTests/AwaitReceptionTest.cs
+++ b/sources/Capsule.Test/AutomatedTests/UnitTests/AwaitReceptionTest.cs
@@ -56,7 +56,7 @@ public class AwaitReceptionTest
     }
     
     [Test]
-    public async Task Await_reception_does_not_throw_exception_when_capsule_method_throws()
+    public async Task Await_reception_does_not_throw_exception_when_capsule_method_throws_but_host_throws()
     {
         var runtimeContext = TestRuntime.Create();
         var hostedService = new CapsuleBackgroundService(
@@ -78,16 +78,16 @@ public class AwaitReceptionTest
         sutInvocationTask.IsCompleted.ShouldBeTrue();
         sutInvocationTask.IsCompletedSuccessfully.ShouldBeTrue();
         
-        // Ensure that the loop is still active and is able to handle a second invocation
-        (await sut.SucceedAlwaysAsync()).ShouldBeTrue();
+        // Ensure that the loop has been terminated
+        await Should.ThrowAsync<CapsuleInvocationException>(async () => await sut.SucceedAlwaysAsync());
         
         await hostedService.StopAsync(CancellationToken.None);
         await Task.Delay(100);
-        await hostedService.ExecuteTask!;
+        await Should.ThrowAsync<InvalidOperationException>(async () => await hostedService.ExecuteTask);
     }
     
     [Test]
-    public async Task Await_reception_does_not_throw_exception_when_capsule_method_is_cancelled()
+    public async Task Await_reception_does_not_throw_exception_when_capsule_method_is_cancelled_but_host_throws()
     {
         var runtimeContext = TestRuntime.Create();
         var hostedService = new CapsuleBackgroundService(
@@ -108,11 +108,11 @@ public class AwaitReceptionTest
         sutInvocationTask.IsCompleted.ShouldBeTrue();
         sutInvocationTask.IsCompletedSuccessfully.ShouldBeTrue();
         
-        // Ensure that the loop is still active and is able to handle a second invocation
-        (await sut.SucceedAlwaysAsync()).ShouldBeTrue();
+        // Ensure that the loop has been terminated
+        await Should.ThrowAsync<CapsuleInvocationException>(async () => await sut.SucceedAlwaysAsync());
         
         await hostedService.StopAsync(CancellationToken.None);
         await Task.Delay(100);
-        await hostedService.ExecuteTask!;
+        await Should.ThrowAsync<OperationCanceledException>(async () => await hostedService.ExecuteTask);
     }
 }

--- a/sources/Capsule.Test/AutomatedTests/UnitTests/InvocationLoopTest.cs
+++ b/sources/Capsule.Test/AutomatedTests/UnitTests/InvocationLoopTest.cs
@@ -1,0 +1,79 @@
+﻿using System.Threading.Channels;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Shouldly;
+
+namespace Capsule.Test.AutomatedTests.UnitTests;
+
+public class InvocationLoopTest
+{
+    [Test]
+    public async Task Invocations_continue_to_be_consumed_with_failure_mode_continue()
+    {
+        var channel = Channel.CreateUnbounded<Func<Task>>();
+        var status = new InvocationLoopStatus();
+
+        var sut = new InvocationLoop(
+            channel.Reader,
+            status,
+            typeof(object),
+            Mock.Of<ILogger<ICapsuleInvocationLoop>>(),
+            CapsuleFailureMode.Continue);
+
+        var invocationCounter = 0;
+
+        var loopTask = sut.RunAsync(CancellationToken.None);
+
+        channel.Writer.TryWrite(async () => invocationCounter++);
+        channel.Writer.TryWrite(async () => throw new Exception("the exception"));
+        channel.Writer.TryWrite(async () => invocationCounter++);
+
+        await Task.Delay(100);
+
+        status.Terminated.ShouldBeFalse();
+        invocationCounter.ShouldBe(2);
+
+        channel.Writer.Complete();
+        await Task.Delay(100);
+        
+        status.Terminated.ShouldBeTrue();
+        invocationCounter.ShouldBe(2);
+        
+        await loopTask;
+    }
+    
+    [Test]
+    public async Task Invocation_loop_is_aborted_with_failure_mode_abort()
+    {
+        var channel = Channel.CreateUnbounded<Func<Task>>();
+        var status = new InvocationLoopStatus();
+
+        var sut = new InvocationLoop(
+            channel.Reader,
+            status,
+            typeof(object),
+            Mock.Of<ILogger<ICapsuleInvocationLoop>>(),
+            CapsuleFailureMode.Abort);
+
+        var invocationException = new Exception("the exception");
+
+        var invocationCounter = 0;
+
+        var loopTask = sut.RunAsync(CancellationToken.None);
+
+        channel.Writer.TryWrite(async () => invocationCounter++);
+        channel.Writer.TryWrite(async () => throw invocationException);
+        channel.Writer.TryWrite(async () => invocationCounter++);
+
+        await Task.Delay(100);
+
+        status.Terminated.ShouldBeTrue();
+        invocationCounter.ShouldBe(1);
+        
+        var loopException = await Should.ThrowAsync<Exception>(async () => await loopTask);
+        loopException.ShouldBe(invocationException);
+    }
+}

--- a/sources/Capsule.Test/AutomatedTests/UnitTests/TestRuntime.cs
+++ b/sources/Capsule.Test/AutomatedTests/UnitTests/TestRuntime.cs
@@ -13,7 +13,9 @@ public static class TestRuntime
             host,
             new DefaultSynchronizerFactory(
                 new DefaultQueueFactory(),
-                new DefaultInvocationLoopFactory(loggerFactory.CreateLogger<ICapsuleInvocationLoop>()),
+                new DefaultInvocationLoopFactory(
+                    loggerFactory.CreateLogger<ICapsuleInvocationLoop>(),
+                    CapsuleFailureMode.Abort),
                 loggerFactory));
     }
 }


### PR DESCRIPTION
### Added

- The failure mode of invocation loops can now be customized. The default is `CapsuleFailureMode.Continue` and leads to the same behavior as before. `CapsuleFailureMode.Abort` can be specified on a newly introduced `CapsuleOptions` parameter on `AddCapsuleHost()`.