### PR TITLE
refactor: Enrich specs in first stage of code generation to simplify code rendering

### DIFF
--- a/sources/Capsule.Generator/CapsuleDefinition.cs
+++ b/sources/Capsule.Generator/CapsuleDefinition.cs
@@ -1,3 +1,0 @@
-﻿namespace Capsule.Generator;
-
-internal record CapsuleDefinition(string InterfaceName, bool GenerateInterface);

--- a/sources/Capsule.Generator/CapsuleSpec.cs
+++ b/sources/Capsule.Generator/CapsuleSpec.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace Capsule.Generator;
+
+internal record CapsuleSpec(INamedTypeSymbol CapsuleClass, CapsuleSpec.ICapsuleInterface Interface)
+{
+    internal interface ICapsuleInterface;
+
+    internal record ProvidedInterface(string Name) : ICapsuleInterface;
+    
+    internal record GeneratedInterface(string Name) : ICapsuleInterface;
+
+    internal record ResolvedInterface(INamedTypeSymbol Symbol) : ICapsuleInterface;
+}

--- a/sources/Capsule.Generator/CapsuleSpecResolver.cs
+++ b/sources/Capsule.Generator/CapsuleSpecResolver.cs
@@ -2,13 +2,13 @@
 
 namespace Capsule.Generator;
 
-internal class CapsuleDefinitionResolver
+internal class CapsuleSpecResolver
 {
     private const string InterfaceNamePropertyName = "InterfaceName";
 
     private const string InterfaceGenerationPropertyName = "InterfaceGeneration";
 
-    public CapsuleDefinition GetCapsuleDefinition(INamedTypeSymbol classSymbol)
+    public CapsuleSpec GetCapsuleDefinition(INamedTypeSymbol classSymbol)
     {
         var capsuleAttribute = classSymbol.GetAttributes()
             .Single(a => a.HasNameAndNamespace(SymbolNames.CapsuleAttributeName, SymbolNames.AttributionNamespace));
@@ -22,18 +22,22 @@ internal class CapsuleDefinitionResolver
         
         var singleInterface = relevantInterfaces.SingleOrDefault();
 
-        var interfaceName = capsuleAttribute.GetProperty(InterfaceNamePropertyName)?.Value as string ??
-                            singleInterface?.Name ?? "I" + classSymbol.Name;
-
         var interfaceGeneration = DetermineInterfaceGeneration(capsuleAttribute) ??
                                   (singleInterface == null
                                       ? InterfaceGeneration.Enable
                                       : InterfaceGeneration.Disable);
+        
+        var interfaceName = capsuleAttribute.GetProperty(InterfaceNamePropertyName)?.Value as string ??
+                            singleInterface?.Name ?? "I" + classSymbol.Name;
 
         var generateInterface = interfaceGeneration == InterfaceGeneration.Enable ||
                                 (interfaceGeneration == InterfaceGeneration.Auto && singleInterface == null);
 
-        return new(interfaceName, generateInterface);
+        return new(
+            classSymbol,
+            generateInterface ? new CapsuleSpec.GeneratedInterface(interfaceName) :
+            singleInterface == null ? new CapsuleSpec.ProvidedInterface(interfaceName) :
+            new CapsuleSpec.ResolvedInterface(singleInterface));
     }
 
     private static InterfaceGeneration? DetermineInterfaceGeneration(AttributeData capsuleAttribute) =>

--- a/sources/Capsule.Generator/ExposeDefinition.cs
+++ b/sources/Capsule.Generator/ExposeDefinition.cs
@@ -1,5 +1,0 @@
-﻿using Microsoft.CodeAnalysis;
-
-namespace Capsule.Generator;
-
-internal record ExposeDefinition(ISymbol Symbol, Synchronization Synchronization, bool PassThroughIfQueueClosed);

--- a/sources/Capsule.Generator/ExposeSpec.cs
+++ b/sources/Capsule.Generator/ExposeSpec.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace Capsule.Generator;
+
+internal record ExposeSpec(
+    ISymbol MemberSymbol,
+    Synchronization Synchronization,
+    bool PassThroughIfQueueClosed);

--- a/sources/Capsule.Generator/ExposeSpecResolver.cs
+++ b/sources/Capsule.Generator/ExposeSpecResolver.cs
@@ -2,7 +2,7 @@
 
 namespace Capsule.Generator;
 
-internal class ExposeDefinitionResolver
+internal class ExposeSpecResolver
 {
     private const string ExposeAttributeName = "ExposeAttribute";
 
@@ -24,7 +24,9 @@ internal class ExposeDefinitionResolver
         isEnabledByDefault: true);
 #pragma warning restore RS2008
     
-    public IEnumerable<ExposeDefinition> GetExposeDefinitions(SourceProductionContext context, INamedTypeSymbol classSymbol)
+    public IEnumerable<ExposeSpec> GetExposeSpecs(
+        SourceProductionContext context,
+        INamedTypeSymbol classSymbol)
     {
         var exposedSymbols = classSymbol.GetMembers()
             .Where(
@@ -35,12 +37,12 @@ internal class ExposeDefinitionResolver
 
         return
         [
-            ..exposedSymbols.Where(s => s.Symbol is IPropertySymbol p && IsExposable(context, p, s.Synchronization)),
-            ..exposedSymbols.Where(s => s.Symbol is IMethodSymbol m && IsExposable(context, m))
+            ..exposedSymbols.Where(s => s.MemberSymbol is IPropertySymbol p && IsExposable(context, p, s.Synchronization)),
+            ..exposedSymbols.Where(s => s.MemberSymbol is IMethodSymbol m && IsExposable(context, m))
         ];
     }
     
-    private static ExposeDefinition GetExposeSpec(ISymbol symbol)
+    private ExposeSpec GetExposeSpec(ISymbol symbol)
     {
         var attr = symbol.GetAttributes().Single(a => a.AttributeClass!.Name == ExposeAttributeName);
 
@@ -51,8 +53,7 @@ internal class ExposeDefinitionResolver
 
         return new (symbol, synchronization, fallbackToPassThrough);
     }
-
-
+    
     private static bool IsExposable(
         SourceProductionContext context,
         IMethodSymbol method)

--- a/sources/Capsule.Generator/NamedTypeSymbolExtensions.cs
+++ b/sources/Capsule.Generator/NamedTypeSymbolExtensions.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace Capsule.Generator;
+
+internal static class NamedTypeSymbolExtensions
+{
+    internal static string NestedTypeQualifiedName(this INamedTypeSymbol symbol) =>
+        symbol.ContainingType == null ? symbol.Name : $"{NestedTypeQualifiedName(symbol.ContainingType)}.{symbol.Name}";
+}


### PR DESCRIPTION
### Changed

- Refactoring: Code generation updated to resolve all relevant information early and store it in the `CapsuleSpec` and `ExposeSpec` objects. This simplifies the later code rendering.