### PR TITLE
feature: The default failure mode is now 'abort' for consistency with .NET background services

### DIFF
--- a/sources/Capsule.Core/DependencyInjection/CapsuleOptions.cs
+++ b/sources/Capsule.Core/DependencyInjection/CapsuleOptions.cs
@@ -7,7 +7,8 @@ public record CapsuleOptions
 {
     /// <summary>
     /// The failure mode that instantiated control loops should use. Defaults to
-    /// <see cref="CapsuleFailureMode.Continue"/>.
+    /// <see cref="CapsuleFailureMode.Abort"/> to provide consistent behavior with
+    /// .NET background services.
     /// </summary>
-    public CapsuleFailureMode FailureMode { get; set; } = CapsuleFailureMode.Continue;
+    public CapsuleFailureMode FailureMode { get; set; } = CapsuleFailureMode.Abort;
 }


### PR DESCRIPTION
### Changed

- The default failure mode is now `Abort`. The previous behavior can be restored by setting `CapsuleOptions.FailureMode` to `Continue`. **Breaking change.**