### PR TITLE
feature: Timer discriminators

### DIFF
--- a/docs/docs/30_usage.md
+++ b/docs/docs/30_usage.md
@@ -144,9 +144,9 @@ Capsule will enqueue a single call to this method when a capsule is instantiated
 
 ### Timers
 
-Run-to-completion semantics dictate that individual runs should complete quickly. In other words, awaiting large delays or even sleeping is discouraged and will break responsiveness of the capsule.
+Run-to-completion semantics dictate that individual runs should complete quickly. In other words, awaiting large delays or even sleeping is discouraged and will break responsiveness of the capsule, potentially leading to invocation queue exhaustion.
 
-To work around this limitation, timers can be used by implementing `CapsuleFeature.ITimers`. When implemented, Capsule will inject an `ITimerService` during encapsulation.
+To work around this limitation, Capsule provides a timer service. The service can be used by making capsules implement `CapsuleFeature.ITimers`. When implemented, Capsule will inject an `ITimerService` during encapsulation.
 
 !!! note
     The timer service will not be available when the constructor of the capsule implementation runs as this would create a chicken-and-egg problem. If you need to start timers when the capsule is instantiated, use an [async initializer](#async-initializer).
@@ -154,6 +154,8 @@ To work around this limitation, timers can be used by implementing `CapsuleFeatu
 You can then use the timer service to register callbacks with a timeout through `StartSingleShot()`. When the timeout expires, the callback will be enqueued as just another invocation. Timers thus adheres to the thread-safety guarantees of the capsule.
 
 Pending timers can also be cancelled. Either cancel a single timer through its `TimerReference`, or cancel all timers through `ITimerService.CancelAll()`.
+
+For cases where only a single timer is needed, but that timer may be restarted multiple times, consider passing a `discriminator` to `StartSingleShot()`. The timer service will then ensure that at most one timer with the same discriminator exists, previous ones will be cancelled.
 
 
 ## Testing

--- a/sources/Capsule.Core/ITimerService.cs
+++ b/sources/Capsule.Core/ITimerService.cs
@@ -4,7 +4,9 @@
 /// Service that provides timers for capsule implementations. Enable timers by implementing
 /// <see cref="CapsuleFeature.ITimers"/> in the capsule implementation. 
 /// </summary>
-/// <remarks>This service is not meant to be used outside of capsule implementations.</remarks>
+/// <remarks>
+/// This service is specifically designed for use in Capsule implementations and is not meant to be used outside of them.
+/// </remarks>
 public interface ITimerService
 {
     /// <summary>
@@ -12,8 +14,18 @@ public interface ITimerService
     /// Then, the <paramref name="callback"/> will be enqueued for execution. The callback will run in the context of
     /// the capsule to guarantee thread-safety in timer callbacks.
     /// </summary>
+    /// <remarks>
+    /// In cases where only one timer of a specific kind is needed (e.g. a retry timer), set a discriminator. The timer
+    /// service will then cancel any existing timer with the same discriminator. This ensures that only one such timer
+    /// exists at any time and timers don't accumulate.
+    /// </remarks>
+    /// <param name="timeout">The time after which <paramref name="callback"/> will be called</param>
+    /// <param name="callback">The callback to execute when the timer expires</param>
+    /// <param name="discriminator">
+    /// If set, the timer service will cancel pre-existing timers with the same discriminator
+    /// </param>
     /// <returns>A reference to the timer that allows cancelling the timer before it expires.</returns>
-    TimerReference StartSingleShot(TimeSpan timeout, Func<Task> callback);
+    TimerReference StartSingleShot(TimeSpan timeout, Func<Task> callback, string? discriminator = null);
 
     /// <summary>
     /// Cancel all pending timers. 

--- a/sources/Capsule.Core/TimerReference.cs
+++ b/sources/Capsule.Core/TimerReference.cs
@@ -8,11 +8,12 @@ public class TimerReference
 {
     private readonly CancellationTokenSource _cancellationTokenSource;
 
-    internal TimerReference(TimeSpan timeout, Task timerTask, CancellationTokenSource cancellationTokenSource)
+    internal TimerReference(TimeSpan timeout, Task timerTask, CancellationTokenSource cancellationTokenSource, string? discriminator = null)
     {
         _cancellationTokenSource = cancellationTokenSource;
         TimerTask = timerTask;
         Timeout = timeout;
+        Discriminator = discriminator;
     }
 
     /// <summary>
@@ -25,6 +26,11 @@ public class TimerReference
     /// The timeout value that the timer uses.
     /// </summary>
     public TimeSpan Timeout { get; }
+    
+    /// <summary>
+    /// The discriminator that is used to identify timer duplicates. Duplicate detection is disabled if this is null.
+    /// </summary>
+    public string? Discriminator { get; }
 
     /// <summary>
     /// Cancel this timer. If the timer has already fired and the callback enqueued, this is a no-op.

--- a/sources/Capsule.Test/Capsule.Test.csproj
+++ b/sources/Capsule.Test/Capsule.Test.csproj
@@ -52,8 +52,12 @@
   <ItemGroup>
     <!-- Conditionally reference either the project or the package. This enables integrated development of features
          that span multiple projects, while still resorting to package references for the published nuget packages. -->
+    <!-- TODO Restore conditional include once Capsule.Testing 3.1.0 is released -->
+    <!--
     <ProjectReference Include="..\Capsule.Testing\Capsule.Testing.csproj" Condition=" '$(Configuration)' == 'Debug' " />
     <PackageReference Include="Capsule.Testing" Version="3.0.0" Condition=" '$(Configuration)' == 'Release' " />
+    -->
+    <ProjectReference Include="..\Capsule.Testing\Capsule.Testing.csproj" />
   </ItemGroup>
 
 </Project>

--- a/sources/Capsule.Testing/Capsule.Testing.csproj
+++ b/sources/Capsule.Testing/Capsule.Testing.csproj
@@ -28,8 +28,12 @@
   <ItemGroup>
     <!-- Conditionally reference either the project or the package. This enables integrated development of features
          that span multiple projects, while still resorting to package references for the published nuget packages. -->
+    <!-- TODO Restore conditional include once Capsule.Core 3.1.0 is released -->
+    <!--
     <ProjectReference Include="..\Capsule.Core\Capsule.Core.csproj" Condition=" '$(Configuration)' == 'Debug' " />
     <PackageReference Include="Capsule.Core" Version="3.0.0" Condition=" '$(Configuration)' == 'Release' " /> 
+    -->
+    <ProjectReference Include="..\Capsule.Core\Capsule.Core.csproj" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">


### PR DESCRIPTION
### Added

- `ITimerService.StartSingleShot()` takes now an optional third parameter `string discriminator`. When a discriminator is provided, the timer service checks whether another timer with the same discriminator has already been started earlier, and if so, cancels the older timer.