### PR TITLE
fix: Support multiple relevant interfaces for picking the capsule interface (uses first one when multiple available)

### DIFF
--- a/sources/Capsule.Generator/CapsuleSpecResolver.cs
+++ b/sources/Capsule.Generator/CapsuleSpecResolver.cs
@@ -21,26 +21,26 @@ internal class CapsuleSpecResolver
                 )
         );
 
-        var singleInterface = relevantInterfaces.SingleOrDefault();
+        var firstRelevantInterface = relevantInterfaces.FirstOrDefault();
 
         var interfaceGeneration =
             DetermineInterfaceGeneration(capsuleAttribute)
-            ?? (singleInterface == null ? InterfaceGeneration.Enable : InterfaceGeneration.Disable);
+            ?? (firstRelevantInterface == null ? InterfaceGeneration.Enable : InterfaceGeneration.Disable);
 
         var interfaceName =
             capsuleAttribute.GetProperty(InterfaceNamePropertyName)?.Value as string
-            ?? singleInterface?.Name
+            ?? firstRelevantInterface?.Name
             ?? "I" + classSymbol.Name;
 
         var generateInterface =
             interfaceGeneration == InterfaceGeneration.Enable
-            || (interfaceGeneration == InterfaceGeneration.Auto && singleInterface == null);
+            || (interfaceGeneration == InterfaceGeneration.Auto && firstRelevantInterface == null);
 
         return new(
             classSymbol,
             generateInterface ? new CapsuleSpec.GeneratedInterface(interfaceName)
-                : singleInterface == null ? new CapsuleSpec.ProvidedInterface(interfaceName)
-                : new CapsuleSpec.ResolvedInterface(singleInterface)
+                : firstRelevantInterface == null ? new CapsuleSpec.ProvidedInterface(interfaceName)
+                : new CapsuleSpec.ResolvedInterface(firstRelevantInterface)
         );
     }
 

--- a/sources/Capsule.Test/AutomatedTests/UnitTests/CodeGenTest.cs
+++ b/sources/Capsule.Test/AutomatedTests/UnitTests/CodeGenTest.cs
@@ -43,6 +43,18 @@ public class CodeGenTest
             sut.SyncMethod();
         });
     }
+
+    [Test]
+    public async Task CapsuleSynchronization_AwaitEnqueuing_with_resolved_and_additional_interface_supports_sync_and_async_interfaces()
+    {
+        var sut = new SyncAsyncTest.WithResolvedAndAdditionalInterface().Encapsulate(TestRuntime.Create());
+
+        await Should.NotThrowAsync(async () =>
+        {
+            await sut.AsyncMethod();
+            sut.SyncMethod();
+        });
+    }
 }
 
 // Verify that deeply nested types can be used as Capsule
@@ -90,6 +102,21 @@ public class SyncAsyncTest
 
         [Expose(Synchronization = CapsuleSynchronization.AwaitEnqueueing)]
         public async Task AsyncMethod() { }
+    }
+
+    [Capsule]
+    public class WithResolvedAndAdditionalInterface : IWithPredefinedInterface, IDisposable
+    {
+        [Expose(Synchronization = CapsuleSynchronization.AwaitEnqueueing)]
+        public void SyncMethod() { }
+
+        [Expose(Synchronization = CapsuleSynchronization.AwaitEnqueueing)]
+        public async Task AsyncMethod() { }
+
+        public void Dispose()
+        {
+            // No op
+        }
     }
 }
 


### PR DESCRIPTION
### Fixed

Capsules can now implement as many interfaces as they want. Before, using more than one non-Capsule-feature interface lead to a code generation error.

When multiple candidates are available as Capsule interface, the first relevant interface is chosen. Relevant interfaces are all non-Capsule-feature interfaces.