### PR TITLE
Feature: Add support for exposing events in Capsule generator

### DIFF
--- a/docs/docs/30_usage.md
+++ b/docs/docs/30_usage.md
@@ -48,12 +48,14 @@ The interface name can be customized through `CapsuleAttribute.InterfaceName`:
     If you bring your own interface, you'll need to ensure it matches the exposed methods and properties. Otherwise, the build will fail.
 
 
-### Exposing Methods & Properties
+### Exposing Methods, Properties & Events {: #exposing-methods-properties }
 
-In addition to the `[Capule]` attribute on the implementation class, you'll need to add the `[Expose]` attribute to all methods and properties that you want to make accessible through the capsule interface. The following restrictions apply:
+In addition to the `[Capsule]` attribute on the implementation class, you'll need to add the `[Expose]` attribute to all methods, properties and events that you want to make accessible through the capsule interface. The following restrictions apply:
 
 - The exposed methods must have a return type that is compatible with the chosen synchronization mode (see below).
 - Properties are restricted to immutable getters and `PassThrough` synchronization mode must be used.
+- Events are restricted to `PassThrough` synchronization mode.
+
 
 The synchronization mode defaults to `AwaitCompletion`. Different modes can be specified through the `ExposeAttribute.Synchronization` property.
 
@@ -94,7 +96,7 @@ A special case regarding sync/async is `AwaitEnqueueing` synchronization mode. T
 
 `AwaitCompletion`, `AwaitEnqueueing` and `AwaitReception` modes provide thread safety :octicons-shield-check-16:, `PassThrough` does not :octicons-shield-slash-16:.
 
-`PassThrough` is not thread-safe because it doesn't enqueue the invocation, but executes it directly. It is *only* safe for immutable operations and is typically used with get-only properties that return an immutable field of the capsule implementation (e.g. an ID).
+`PassThrough` is not thread-safe because it doesn't enqueue the invocation, but executes it directly. It is *only* safe for immutable operations and is typically used with get-only properties that return an immutable field of the capsule implementation (e.g. an ID), or for events.
 
 `AwaitCompletionOrPassThroughIfQueueClosed` is a special case synchronization mode that behaves as `AwaitCompletion`, but falls back to `PassThrough` if the invocation queue has been closed. This is useful for `DisposeAsync()` operations, where `DisposeAsync()` may be called by DI infrastructure just before shutdown. At that point, the invocation queue has already been terminated and `AwaitCompletion` would throw a `CapsuleInvocationException`. When it falls back to `PassThrough`, thread-safety is not guaranteed.
 

--- a/sources/Capsule.Core/Attribution/ExposeAttribute.cs
+++ b/sources/Capsule.Core/Attribution/ExposeAttribute.cs
@@ -7,7 +7,7 @@
 /// The synchronization mode can be customized by specifying the <see cref="Synchronization"/> property, which defaults
 /// to "await completion and return result".
 /// </summary>
-[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property)]
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Event)]
 public sealed class ExposeAttribute : Attribute
 {
     public CapsuleSynchronization Synchronization { get; init; } = CapsuleSynchronization.AwaitCompletion;

--- a/sources/Capsule.Generator/CodeRenderer.cs
+++ b/sources/Capsule.Generator/CodeRenderer.cs
@@ -178,12 +178,12 @@ internal class CodeRenderer(
         }
 
         return $$"""
-                    public event {{type}} {{name}}
-                        {
-                            add => _impl.{{name}} += value;
-                            remove => _impl.{{name}} -= value;
-                        }
-                """;
+                public event {{type}} {{name}}
+                    {
+                        add => _impl.{{name}} += value;
+                        remove => _impl.{{name}} -= value;
+                    }
+            """;
     }
 
     private static bool IsValueTask(ITypeSymbol typeSymbol) =>

--- a/sources/Capsule.Generator/CodeRenderer.cs
+++ b/sources/Capsule.Generator/CodeRenderer.cs
@@ -179,10 +179,10 @@ internal class CodeRenderer(
 
         return $$"""
                     public event {{type}} {{name}}
-                    {
-                        add => _impl.{{name}} += value;
-                        remove => _impl.{{name}} -= value;
-                    }
+                        {
+                            add => _impl.{{name}} += value;
+                            remove => _impl.{{name}} -= value;
+                        }
                 """;
     }
 

--- a/sources/Capsule.Generator/CodeRenderer.cs
+++ b/sources/Capsule.Generator/CodeRenderer.cs
@@ -100,6 +100,7 @@ internal class CodeRenderer(
                 renderImplementation
             ),
             IPropertySymbol p => RenderHullProperty(p, exposeSpec.Synchronization, renderImplementation),
+            IEventSymbol e => RenderHullEvent(e, renderImplementation),
             _ => throw new ArgumentOutOfRangeException(nameof(exposeSpec.MemberSymbol)),
         };
     }
@@ -164,6 +165,25 @@ internal class CodeRenderer(
                         """
                     : " { get; }"
             );
+    }
+
+    private static string RenderHullEvent(IEventSymbol evt, bool renderImplementation)
+    {
+        var type = evt.Type.ToDisplayString();
+        var name = evt.Name;
+
+        if (!renderImplementation)
+        {
+            return $"public event {type} {name};";
+        }
+
+        return $$"""
+                    public event {{type}} {{name}}
+                    {
+                        add => _impl.{{name}} += value;
+                        remove => _impl.{{name}} -= value;
+                    }
+                """;
     }
 
     private static bool IsValueTask(ITypeSymbol typeSymbol) =>

--- a/sources/Capsule.Generator/ExposeSpecResolver.cs
+++ b/sources/Capsule.Generator/ExposeSpecResolver.cs
@@ -64,7 +64,9 @@ internal class ExposeSpecResolver
                 s.MemberSymbol is IPropertySymbol p && IsExposable(context, p, s.Synchronization)
             ),
             .. exposedSymbols.Where(s => s.MemberSymbol is IMethodSymbol m && IsExposable(context, m)),
-            .. exposedSymbols.Where(s => s.MemberSymbol is IEventSymbol e && IsExposable(context, e, s.Synchronization)),
+            .. exposedSymbols.Where(s =>
+                s.MemberSymbol is IEventSymbol e && IsExposable(context, e, s.Synchronization)
+            ),
         ];
     }
 
@@ -175,11 +177,7 @@ internal class ExposeSpecResolver
         return exposable;
     }
 
-    private static bool IsExposable(
-        SourceProductionContext context,
-        IEventSymbol evt,
-        Synchronization synchronization
-    )
+    private static bool IsExposable(SourceProductionContext context, IEventSymbol evt, Synchronization synchronization)
     {
         var exposable = true;
 

--- a/sources/Capsule.Generator/ExposeSpecResolver.cs
+++ b/sources/Capsule.Generator/ExposeSpecResolver.cs
@@ -26,6 +26,15 @@ internal class ExposeSpecResolver
         DiagnosticSeverity.Error,
         isEnabledByDefault: true
     );
+
+    private static readonly DiagnosticDescriptor UnexposableEventError = new(
+        id: "CAPSULEGEN0003",
+        title: "Event cannot be exposed",
+        messageFormat: "Cannot expose event '{0}': {1}",
+        category: "CapsuleGen",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true
+    );
 #pragma warning restore RS2008
 
     private readonly HashSet<INamedTypeSymbol> _taskTypeSymbols;
@@ -55,6 +64,7 @@ internal class ExposeSpecResolver
                 s.MemberSymbol is IPropertySymbol p && IsExposable(context, p, s.Synchronization)
             ),
             .. exposedSymbols.Where(s => s.MemberSymbol is IMethodSymbol m && IsExposable(context, m)),
+            .. exposedSymbols.Where(s => s.MemberSymbol is IEventSymbol e && IsExposable(context, e, s.Synchronization)),
         ];
     }
 
@@ -64,7 +74,11 @@ internal class ExposeSpecResolver
 
         var synchronizationPropertyValue = attr.GetProperty(SynchronizationPropertyName)?.Value as int?;
 
-        var synchronization = SynchronizerMethod(synchronizationPropertyValue);
+        var synchronization =
+            symbol is IEventSymbol && synchronizationPropertyValue is null
+                ? Synchronization.PassThrough
+                : SynchronizerMethod(synchronizationPropertyValue);
+
         var fallbackToPassThrough = PassThroughAsFallback(synchronizationPropertyValue);
 
         // Determine asyncness based on return type (there seems to be no better way)
@@ -152,6 +166,45 @@ internal class ExposeSpecResolver
                     property.Locations.FirstOrDefault(),
                     property.Name,
                     "Only Synchronization.PassThrough synchronization mode is supported for properties."
+                )
+            );
+
+            exposable = false;
+        }
+
+        return exposable;
+    }
+
+    private static bool IsExposable(
+        SourceProductionContext context,
+        IEventSymbol evt,
+        Synchronization synchronization
+    )
+    {
+        var exposable = true;
+
+        if (evt.DeclaredAccessibility is not Accessibility.Public and not Accessibility.Internal)
+        {
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    UnexposableEventError,
+                    evt.Locations.FirstOrDefault(),
+                    evt.Name,
+                    "Exposed events must have public or internal accessibility."
+                )
+            );
+
+            exposable = false;
+        }
+
+        if (synchronization != Synchronization.PassThrough)
+        {
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    UnexposableEventError,
+                    evt.Locations.FirstOrDefault(),
+                    evt.Name,
+                    "Only Synchronization.PassThrough synchronization mode is supported for events."
                 )
             );
 

--- a/sources/Capsule.Test/AutomatedTests/UnitTests/EventCodeGenTest.cs
+++ b/sources/Capsule.Test/AutomatedTests/UnitTests/EventCodeGenTest.cs
@@ -1,0 +1,39 @@
+using Capsule.Attribution;
+using Shouldly;
+
+namespace Capsule.Test.AutomatedTests.UnitTests
+{
+    public class EventCodeGenTest
+    {
+        [Test]
+        public void Can_expose_events_defined_in_interface_automatically()
+        {
+            var impl = new EventCapsule();
+            var sut = impl.Encapsulate(TestRuntime.Create());
+
+            bool eventRaised = false;
+            sut.MyEvent += (sender, args) => eventRaised = true;
+
+            impl.RaiseEvent();
+
+            eventRaised.ShouldBeTrue();
+        }
+
+        [Capsule]
+        public class EventCapsule : IEventInterface
+        {
+            [Expose(Synchronization = CapsuleSynchronization.PassThrough)]
+            public event EventHandler? MyEvent;
+
+            public void RaiseEvent()
+            {
+                MyEvent?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        public interface IEventInterface
+        {
+            event EventHandler MyEvent;
+        }
+    }
+}


### PR DESCRIPTION
Enables the Capsule source generator to expose C# events.

Generation: Creates pass-through add/remove accessors for events marked with [Expose].
Validation: Enforces Synchronization.PassThrough and checks accessibility.